### PR TITLE
Lighting items when uses more 2 level depth

### DIFF
--- a/NavX.php
+++ b/NavX.php
@@ -113,12 +113,10 @@ class NavX extends \yii\bootstrap\Nav
                     $active = true;
                 }
             }
-            if (is_array($items[$i]['items']))
-            {
+            if (is_array($items[$i]['items'])) {
                 $childActive = false;
                 $items[$i]['items'] = $this->isChildActive($items[$i]['items'], $childActive);
-                if ($childActive)
-                {
+                if ($childActive) {
                     Html::addCssClass($items[$i]['options'], 'active');
                     $active = true;
                 }


### PR DESCRIPTION
Upgrade `isChildActive` method for lighting items when uses more 2 level depth.

Example: 

``` php
echo NavX::widget([
    'options' => ['class' => 'navbar-nav'],
    'encodeLabels' => false,
    'activateParents' => true,
    'items' => [
        [
            'label' => Icon::show('reorder') . Yii::t('app', 'Modules'),
            'items' => [
                [
                    'label' => Icon::show('image') . Yii::t('app', 'Photos'),
                    'items' => [
                        [
                            'label' => Icon::show('sort-alpha-asc') . Yii::t('app', 'All'),
                            'url' => ['/photos/default/index'],
                        ],
                        [
                            'label' => Icon::show('folder') . Yii::t('app', 'Categories'),
                            'url' => ['/photos/categories/index'],
                        ],
                    ],
                ],
            ],
        ]
    ],
]);
```
